### PR TITLE
TagSelectorのカーソルをpointerに変更

### DIFF
--- a/components/work/TagSelector.vue
+++ b/components/work/TagSelector.vue
@@ -137,4 +137,9 @@ export default {
 	width: auto;
 	z-index: 10;
 }
+
+.tag-selector-header >>> .vs__dropdown-toggle,
+.tag-selector-header >>> .vs__search {
+	cursor: pointer;
+}
 </style>


### PR DESCRIPTION
# 変更点

タグ選択のセレクターのカーソルをpointerに変更

# 変更理由

デフォルトのカーソルは `text` になっていたが、今回の用途では不適切だと考えたため