### PR TITLE
タグをクリアするボタンの見た目を変更

### DIFF
--- a/components/work/TagClearButton.vue
+++ b/components/work/TagClearButton.vue
@@ -1,0 +1,42 @@
+<template>
+  <div 
+    class="clear-button"
+    :class="{'disabled': disabled}" 
+    @click="$emit('click')"
+  >
+    クリア
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'TagClearButton',
+  props: {
+    disabled: {
+      type: Boolean,
+      default: false
+    }
+  }
+}
+</script>
+
+<style scoped>
+.clear-button {
+  font-size: small;
+  padding: .3rem .7rem;
+  border: 1px solid;
+  border-radius: 4px;
+  cursor: pointer;
+  box-shadow: 3px 3px 3px rgba(0,0,0,0.1);
+  transition: .15s cubic-bezier(0.45, 0, 0.55, 1);
+  user-select: none;
+}
+.clear-button:hover {
+  background-color: #e9e9e9;
+}
+
+.disabled {
+  opacity: .5;
+  pointer-events: none;
+}
+</style>

--- a/components/work/TagSelector.vue
+++ b/components/work/TagSelector.vue
@@ -3,7 +3,11 @@
 		<div class="tag-selector-header">
 			<font-awesome-icon icon="search" />
 			<div class="label">タグで探す</div>
-			<TagButton class="all-select-button" name="クリア" color="#808080" :enabled="selectedTags.length > 0" small @click="clearSelectedTags" />
+			<TagClearButton
+				class="tag-clear-button"
+				:disabled="selectedTags.length <= 0"
+				@click="clearSelectedTags"
+			/>
 			<v-select class="tag-select" :options="options" :value="[]" @option:selected="handleSelect" />
 		</div>
 		<div class="tag-list-container">
@@ -18,7 +22,7 @@
 	</div>
 </template>
 <script>
-import TagButton from './TagButton'
+import TagClearButton from './TagClearButton.vue'
 import VSelect from 'vue-select'
 /**
  * type Tag = {
@@ -34,7 +38,7 @@ export default {
 		event: 'selectTags'
 	},
 	components: {
-		TagButton,
+		TagClearButton,
 		VSelect
 	},
 	props: {
@@ -112,8 +116,8 @@ export default {
 	user-select: none;
 }
 
-.all-select-button {
-	margin-left: .5rem;
+.tag-clear-button {
+	margin: 0 1rem;
 }
 
 .tag-list-container {


### PR DESCRIPTION
# 変更点

選択したタグをクリアするボタンの見た目を変更した

### before

![image](https://user-images.githubusercontent.com/43461456/179074579-a9b58c5f-1056-4fab-8416-1b5407049d79.png)


### after

![image](https://user-images.githubusercontent.com/43461456/179074519-8d55ca68-14e4-4f30-9c25-0e461892396d.png)


# 変更理由

タグと見た目が同じでボタンだと気づきにくい可能性があると考えたため
